### PR TITLE
Add Last Seen extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -88,6 +88,14 @@
         "env": "all"
     },
     {
+        "user": "Wingysam",
+        "id": "xyz.wingysam.lastseen",
+        "title": "Last Seen",
+        "description": "Tell players where someone was last seen! - Adds the where command. /where wingysam",
+        "env": "browser+cloud",
+        "package": "https://wingysam.github.io/BHMB-LastSeen/extension.js"
+    },
+    {
         "user": "Bibliophile",
         "id": "bibliofile/lists",
         "package": "https://bibliofile.github.io/BHMB-List-Manager/build/bundle.js",


### PR DESCRIPTION
I've published Last Seen's extension to GitHub and would like it to be in the default repo.

~~this may or may not be for hacktoberfest~~